### PR TITLE
Cross Platform Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ All the videos will be in MPEG-4 Part 14 (MP4 😉) format.
 
 ![fb_v](demo.gif)
 
-## Git Installation
+## Clone & Configure
 ```
 # clone the repo
-$ git clone git@github.com:duongxthanh/facebook-reels-downloader.git
+$ git clone https://github.com/duongxthanh/facebook-reels-downloader.git
 
 # change the working directory to facebook-reels-downloader
 $ cd facebook-reels-downloader
 
 # install the requirements
-$ pip3 install -r requirements.txt
+$ pip install -r requirements.txt
 ```
 ## Usage
 ```
-python3 reels.py <channel_name> <channel_reel_url>
+python reels.py <channel_name> <channel_reel_url>
 ```
 
 ## For your Attention

--- a/reels.py
+++ b/reels.py
@@ -1,6 +1,7 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from time import sleep
+import os
 import subprocess
 import csv
 import sys
@@ -44,19 +45,19 @@ for _ in range(scroll_steps):
 
     prev_scroll_position = curr_scroll_position
 
-# Extract reel urls
+# Extract reel URLs
 a_elements = driver.find_elements(By.CSS_SELECTOR, 'a')
 
-# Create a chanel output dir
-args = ["mkdir", "-p", f"output/{chanel}"]
-subprocess.run(args)
+# Create a chanel output directory (cross-platform)
+os.makedirs(f"output/{chanel}", exist_ok=True)
 
+# Save the extracted URLs to a CSV file
 with open(f"output/{chanel}.csv", "w") as f:
-  writer = csv.writer(f)
-  for element in a_elements:
-      href = element.get_attribute('href')
-      if href and '/reel/' in href:
-          writer.writerow([href.split('/?s=')[0]])
+    writer = csv.writer(f)
+    for element in a_elements:
+        href = element.get_attribute('href')
+        if href and '/reel/' in href:
+            writer.writerow([href.split('/?s=')[0]])
 
 f.close()
 driver.quit()

--- a/reels.py
+++ b/reels.py
@@ -7,7 +7,8 @@ import csv
 import sys
 
 # Initialize the WebDriver
-driver = webdriver.Chrome()
+# Ensure the chromedriver is in the system path or provide the absolute path
+driver = webdriver.Chrome()  # Update if needed, e.g., webdriver.Chrome(executable_path='/path/to/chromedriver')
 driver.maximize_window()
 
 # Open the webpage
@@ -49,10 +50,12 @@ for _ in range(scroll_steps):
 a_elements = driver.find_elements(By.CSS_SELECTOR, 'a')
 
 # Create a chanel output directory (cross-platform)
-os.makedirs(f"output/{chanel}", exist_ok=True)
+output_dir = os.path.join("output", chanel)
+os.makedirs(output_dir, exist_ok=True)
 
 # Save the extracted URLs to a CSV file
-with open(f"output/{chanel}.csv", "w") as f:
+csv_path = os.path.join("output", f"{chanel}.csv")
+with open(csv_path, "w") as f:
     writer = csv.writer(f)
     for element in a_elements:
         href = element.get_attribute('href')
@@ -63,7 +66,7 @@ f.close()
 driver.quit()
 
 # Bulk download reels with yt-dlp
-args = ["yt-dlp", "-f", "best", "-a", f"output/{chanel}.csv", "--output", f"output/{chanel}/%(id)s.%(ext)s"]
+args = ["yt-dlp", "-f", "best", "-a", csv_path, "--output", os.path.join(output_dir, "%(id)s.%(ext)s")]
 process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 for line in iter(lambda: process.stdout.readline(), b''):
     print(line.decode("utf-8"))


### PR DESCRIPTION
### Cross Platform Support

 - Instead of `mkdir` from Unix, use `os.mkdir()`
 - Instead of `/`, use `path.join()`